### PR TITLE
Feature/activate insert by incremental key

### DIFF
--- a/core/dbio/database/database.go
+++ b/core/dbio/database/database.go
@@ -2884,11 +2884,20 @@ func (conn *BaseConn) CompareChecksums(tableName string, columns iop.Columns) (e
 		exprMap[strings.ToLower(col.Name)] = g.F("sum(%s)", expr)
 	}
 
-	sql := g.F(
-		"select %s from %s ",
-		strings.Join(exprs, ", "),
-		tableName,
-	)
+	var sql string
+	if conn.GetType() == dbio.TypeDbProton {
+		sql = g.F(
+			"select %s from table(%s) ",
+			strings.Join(exprs, ", "),
+			tableName,
+		)
+	} else {
+		sql = g.F(
+			"select %s from %s ",
+			strings.Join(exprs, ", "),
+			tableName,
+		)
+	}
 
 	data, err := conn.Self().Query(sql)
 	if err != nil {

--- a/core/dbio/templates/proton.yaml
+++ b/core/dbio/templates/proton.yaml
@@ -9,6 +9,8 @@ core:
   update: alter stream {table} update {set_fields} where {pk_fields_equal}
   insert_from_table: insert into {tgt_table} ({tgt_fields}) select {src_fields} from table({src_table})
   incremental_select: select {fields} from table({table}) where {incremental_where_cond} order by {update_key} asc
+  limit: select {fields} from table({table}) limit {limit} offset {offset}
+  limit_offset: select {fields} from table({table}) limit {limit}
 
 metadata:
   current_database: select current_database()
@@ -96,7 +98,7 @@ metadata:
       and tables.table_name = cols.table
     order by cols.database, cols.table, cols.position
 
-  ddl_table: SHOW CREATE STREAM `{schema}`.`{table}`
+  ddl_table: SHOW CREATE `{schema}`.`{table}`
 
   ddl_view: |
     SHOW CREATE VIEW `{schema}`.`{table}`

--- a/core/dbio/templates/proton.yaml
+++ b/core/dbio/templates/proton.yaml
@@ -8,6 +8,7 @@ core:
   modify_column: "{column} {type}"
   update: alter stream {table} update {set_fields} where {pk_fields_equal}
   insert_from_table: insert into {tgt_table} ({tgt_fields}) select {src_fields} from table({src_table})
+  incremental_select: select {fields} from table({table}) where {incremental_where_cond} order by {update_key} asc
 
 metadata:
   current_database: select current_database()

--- a/core/sling/task_func.go
+++ b/core/sling/task_func.go
@@ -193,12 +193,20 @@ func getIncrementalValue(cfg *Config, tgtConn database.Connection, srcConnVarMap
 		return // target table does not exist
 	}
 
-	sql := g.F(
-		"select max(%s) as max_val from %s",
-		tgtConn.Quote(tgtUpdateKey, false),
-		table.FDQN(),
-	)
-
+	var sql string
+	if tgtConn.GetType() == dbio.TypeDbProton {
+		sql = g.F(
+			"select max(%s) as max_val from table(%s)",
+			tgtConn.Quote(tgtUpdateKey, false),
+			table.FDQN(),
+		)
+	} else {
+		sql = g.F(
+			"select max(%s) as max_val from %s",
+			tgtConn.Quote(tgtUpdateKey, false),
+			table.FDQN(),
+		)
+	}
 	data, err := tgtConn.Query(sql)
 	if err != nil {
 		errMsg := strings.ToLower(err.Error())


### PR DESCRIPTION
make `./sling run  --update-key _tp_time  --src-conn PROTON --src-stream 'new'  --tgt-conn PROTON --tgt-object 'old'  --mode incremental` possible.
previous it will try use streaming query to get some update key info, and stuck.
we need historical / table query.