### PR TITLE
disable sling update because we have no time to verify it works or not.

### DIFF
--- a/cmd/sling/sling_cli.go
+++ b/cmd/sling/sling_cli.go
@@ -365,7 +365,7 @@ func init() {
 
 	cliConns.Make().Add()
 	cliRun.Make().Add()
-	cliUpdate.Make().Add()
+	// cliUpdate.Make().Add()
 	cliCleanPartitions.Make().Add()
 
 	if projectID == "" {
@@ -508,9 +508,10 @@ func cliInit(done chan struct{}) int {
 	setSentry()
 	ok, err := g.CliProcess()
 
-	if time.Now().UnixMicro()%20 == 0 {
-		defer SlingMedia.PrintFollowUs()
-	}
+	// I am not ready to show follow us yet @yokofly
+	// if time.Now().UnixMicro()%20 == 0 {
+	// 	defer SlingMedia.PrintFollowUs()
+	// }
 
 	if err != nil || env.TelMap["error"] != nil {
 		if err == nil && env.TelMap["error"] != nil {

--- a/cmd/sling/sling_update.go
+++ b/cmd/sling/sling_update.go
@@ -171,6 +171,12 @@ func upgradeScoop() (err error) {
 }
 
 func checkUpdate(force bool) {
+	// do not check update for timeplus version
+	if strings.Contains(core.Version, "timeplus") {
+		g.Debug("Using Timeplus version, skipping update check")
+		return
+	}
+
 	if core.Version == "dev" {
 		return
 	} else if time.Now().Second()%4 != 0 && !force {


### PR DESCRIPTION
as titled,  disable because we have no time to verify if this break or not. (main repo sling , forked repo timeplus-io) the default link is sling-io, I am worried if upstream published new one, and introduce some incompatible function with current our forked.

previous
```
✗ ./sling --help                              
sling - An Extract-Load tool | https://slingdata.io
Slings data from a data source to a data target.
Version dev

  Usage:
    sling [clean-partitions|conns|run|update]

  Subcommands: 
    clean-partitions   Clean daily data for Timeplusd (Proton) tables
    conns              Manage and interact with local connections
    run                Execute a run
    update             Update Sling to the latest version

  Flags: 
       --version   Displays the program version string.
    -h --help      Displays help with available flag, subcommand, and positional value parameters.

```

now
```
✗ ./sling --help
sling - An Extract-Load tool | https://slingdata.io
Slings data from a data source to a data target.
Version dev

  Usage:
    sling [clean-partitions|conns|run]

  Subcommands: 
    clean-partitions   Clean daily data for Timeplusd (Proton) tables
    conns              Manage and interact with local connections
    run                Execute a run

  Flags: 
       --version   Displays the program version string.
    -h --help      Displays help with available flag, subcommand, and positional value parameters.

```