### PR TITLE
manual set _tp_sn type non-nullable to fix below err

### DIFF
--- a/core/dbio/database/database_proton.go
+++ b/core/dbio/database/database_proton.go
@@ -481,5 +481,10 @@ func (conn *ProtonConn) GetNativeType(col iop.Column) (nativeType string, err er
 		return "datetime64(3, 'UTC') DEFAULT now64(3, 'UTC') CODEC(DoubleDelta, LZ4)", nil
 	}
 
+	// special case for _tp_sn, Column _tp_sn is reserved, expected type is non-nullable int64
+	if col.Name == "_tp_sn" {
+		return "int64 CODEC(Delta(8), ZSTD(1))", nil
+	}
+
 	return nativeType, err
 }


### PR DESCRIPTION
because when creation table, sling expected thoes type be nullable. but this is internal column:
```
code: 44, message: Column _tp_sn is reserved, expected type 'int64 ' but actual type 'Function_nullable'.
```