### PR TITLE
(bugfix) proton.yml: remove order by in the incremental_select

### DIFF
--- a/core/dbio/templates/proton.yaml
+++ b/core/dbio/templates/proton.yaml
@@ -8,7 +8,7 @@ core:
   modify_column: "{column} {type}"
   update: alter stream {table} update {set_fields} where {pk_fields_equal}
   insert_from_table: insert into {tgt_table} ({tgt_fields}) select {src_fields} from table({src_table})
-  incremental_select: select {fields} from table({table}) where {incremental_where_cond} order by {update_key} asc
+  incremental_select: select {fields} from table({table}) where {incremental_where_cond}
   limit: select {fields} from table({table}) limit {limit}
   limit_offset: select {fields} from table({table}) limit {limit} offset {offset}
 


### PR DESCRIPTION
i do not know why we need this one, this sorting run out of my memory