### PR TITLE
apply more detailed column type mapping

### DIFF
--- a/core/dbio/templates/types_native_to_general.tsv
+++ b/core/dbio/templates/types_native_to_general.tsv
@@ -369,7 +369,7 @@ proton	string	text	col_string string	TRUE	TRUE
 proton	tuple	string	col_tuple tuple	TRUE	TRUE	
 proton	uint16	integer	col_uint16 uint16	TRUE	TRUE	
 proton	uint32	bigint	col_uint32 uint32	TRUE	TRUE	
-proton	uint64	decimal(28,0)	col_uint64 uint64	TRUE	TRUE	
+proton	uint64	bigint	col_uint64 uint64	TRUE	TRUE	
 proton	uint8	integer	col_uint8 uint8	TRUE	TRUE	
 proton	json	json	col_json json	FALSE	FALSE	
 proton	map	json	col_map json	FALSE	FALSE	

--- a/core/dbio/templates/types_native_to_general.tsv
+++ b/core/dbio/templates/types_native_to_general.tsv
@@ -373,7 +373,8 @@ proton	uint64	bigint	col_uint64 uint64	TRUE	TRUE
 proton	uint8	integer	col_uint8 uint8	TRUE	TRUE	
 proton	json	json	col_json json	FALSE	FALSE	
 proton	map	json	col_map json	FALSE	FALSE	
-proton	lowcardinality	string	col_lowcardinality json	FALSE	FALSE	
+proton	low_cardinality	string	col_lowcardinality json	FALSE	FALSE	
+proton	bool	bool	col_boolean boolean	TRUE	FALSE	
 proton	enum8	string	col_enum8 json	FALSE	FALSE	
 proton	ipv6	string	col_enum8 json	FALSE	FALSE	
 redshift	bigint	bigint	col_bigint bigint	TRUE	TRUE	signed eight-byte integer

--- a/core/sling/task_run_write.go
+++ b/core/sling/task_run_write.go
@@ -276,7 +276,7 @@ func (t *TaskExecution) WriteToDb(cfg *Config, df *iop.Dataflow, tgtConn databas
 	}()
 
 	cfg.Target.TmpTableCreated = true
-	if tgtConn.GetType() != dbio.TypeDbProton {
+	if !(cfg.Target.Type == dbio.TypeDbProton && cfg.Mode == IncrementalMode) {
 		df.Columns = sampleData.Columns
 	}
 	setStage("4 - load-into-temp")


### PR DESCRIPTION
- exit earlier if there is no target table under incremental mode + proton
- map<str, str> and array<int64> current they are not work because we cannot convert from str (probably we can enhance)
- add keep_sling_temp? for the inter-mediate CSV file.