### PR TITLE
Bugfix/issue 34 col name conflict

### DIFF
--- a/core/dbio/database/database_proton.go
+++ b/core/dbio/database/database_proton.go
@@ -435,6 +435,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 					row[colI] = val
 				}
 				eG.Capture(err)
+			} else {
+				row[colI] = decimal.Zero
+				g.Debug("decimal if value == nil")
 			}
 		}
 
@@ -442,6 +445,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToBoolE(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = false
+				g.Debug("boolean if value == nil")
 			}
 		}
 
@@ -449,6 +455,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToStringE(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = ""
+				g.Debug("string if value == nil")
 			}
 		}
 
@@ -456,6 +465,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToInt8E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = int8(0)
+				g.Debug("int8 if value == nil")
 			}
 		}
 
@@ -463,6 +475,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToInt16E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = int16(0)
+				g.Debug("int16 if value == nil")
 			}
 		}
 
@@ -470,6 +485,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToInt32E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = int32(0)
+				g.Debug("int32 if value == nil")
 			}
 		}
 
@@ -478,6 +496,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToIntE(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = int(0)
+				g.Debug("int if value == nil")
 			}
 		}
 
@@ -486,6 +507,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToInt64E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = int64(0)
+				g.Debug("int64 if value == nil")
 			}
 		}
 
@@ -493,6 +517,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToUint8E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = uint8(0)
+				g.Debug("uint8 if value == nil")
 			}
 		}
 
@@ -500,6 +527,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToUint16E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = uint16(0)
+				g.Debug("uint16 if value == nil")
 			}
 		}
 
@@ -508,6 +538,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToUint32E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = uint32(0)
+				g.Debug("uint32 if value == nil")
 			}
 		}
 
@@ -516,6 +549,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToUint64E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = uint64(0)
+				g.Debug("uint64 if value == nil")
 			}
 		}
 
@@ -524,6 +560,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToFloat64E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = float64(0)
+				g.Debug("float64 if value == nil")
 			}
 		}
 
@@ -531,6 +570,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToFloat32E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = float32(0)
+				g.Debug("float32 if value == nil")
 			}
 		}
 
@@ -538,6 +580,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = cast.ToFloat64E(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = float64(0)
+				g.Debug("float64 if value == nil")
 			}
 		}
 
@@ -545,6 +590,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayString(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []string{}
+				g.Debug("empty arraystring if value == nil")
 			}
 		}
 
@@ -552,6 +600,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayBool(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []bool{}
+				g.Debug("empty arrayboolean if value == nil")
 			}
 		}
 
@@ -559,6 +610,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayInt8(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []int8{}
+				g.Debug("empty arrayint8 if value == nil")
 			}
 		}
 
@@ -566,6 +620,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayInt16(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []int16{}
+				g.Debug("empty arrayint16 if value == nil")
 			}
 		}
 
@@ -573,6 +630,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayInt32(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []int32{}
+				g.Debug("empty arrayint32 if value == nil")
 			}
 		}
 
@@ -580,6 +640,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayInt64(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []int64{}
+				g.Debug("empty arrayint64 if value == nil")
 			}
 		}
 
@@ -587,6 +650,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayUint8(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []uint8{}
+				g.Debug("empty arrayuint8 if value == nil")
 			}
 		}
 
@@ -594,6 +660,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayUint16(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []uint16{}
+				g.Debug("empty arrayuint16 if value == nil")
 			}
 		}
 
@@ -601,6 +670,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayUint32(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []uint32{}
+				g.Debug("empty arrayuint32 if value == nil")
 			}
 		}
 
@@ -608,6 +680,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayUint64(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []uint64{}
+				g.Debug("empty arrayuint64 if value == nil")
 			}
 		}
 
@@ -615,6 +690,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayFloat32(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []float32{}
+				g.Debug("empty arrayfloat32 if value == nil")
 			}
 		}
 
@@ -622,6 +700,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToArrayFloat64(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = []float64{}
+				g.Debug("empty arrayfloat64 if value == nil")
 			}
 		}
 
@@ -629,6 +710,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringString(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string]string{}
+				g.Debug("empty mapstringstring if value == nil")
 			}
 		}
 
@@ -636,6 +720,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringInt32(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string]int32{}
+				g.Debug("empty mapstringint32 if value == nil")
 			}
 		}
 
@@ -643,6 +730,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringInt64(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string]int64{}
+				g.Debug("empty mapstringint64 if value == nil")
 			}
 		}
 
@@ -650,6 +740,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringUint32(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string]uint32{}
+				g.Debug("empty mapstringuint32 if value == nil")
 			}
 		}
 
@@ -657,6 +750,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringUint64(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string]uint64{}
+				g.Debug("empty mapstringuint64 if value == nil")
 			}
 		}
 
@@ -664,6 +760,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringFloat64(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string]float64{}
+				g.Debug("empty mapstringfloat64 if value == nil")
 			}
 		}
 
@@ -671,6 +770,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringFloat32(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string]float32{}
+				g.Debug("empty mapstringfloat32 if value == nil")
 			}
 		}
 
@@ -678,6 +780,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapStringArrayString(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[string][]string{}
+				g.Debug("empty mapstringarraystring if value == nil")
 			}
 		}
 
@@ -685,6 +790,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapInt32String(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[int32]string{}
+				g.Debug("empty mapint32string if value == nil")
 			}
 		}
 
@@ -692,6 +800,9 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 			if row[colI] != nil {
 				row[colI], err = conn.convertToMapInt64String(row[colI])
 				eG.Capture(err)
+			} else {
+				row[colI] = map[int64]string{}
+				g.Debug("empty mapint64string if value == nil")
 			}
 		}
 
@@ -921,9 +1032,6 @@ func (conn *ProtonConn) GetNativeType(col iop.Column) (nativeType string, err er
 
 // Array types
 func (conn *ProtonConn) convertToArrayString(value interface{}) ([]string, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []string{}, nil
@@ -944,9 +1052,6 @@ func (conn *ProtonConn) convertToArrayString(value interface{}) ([]string, error
 }
 
 func (conn *ProtonConn) convertToArrayInt8(value interface{}) ([]int8, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []int8{}, nil
@@ -967,9 +1072,6 @@ func (conn *ProtonConn) convertToArrayInt8(value interface{}) ([]int8, error) {
 }
 
 func (conn *ProtonConn) convertToArrayInt16(value interface{}) ([]int16, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []int16{}, nil
@@ -989,9 +1091,6 @@ func (conn *ProtonConn) convertToArrayInt16(value interface{}) ([]int16, error) 
 	return result, nil
 }
 func (conn *ProtonConn) convertToArrayInt32(value interface{}) ([]int32, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []int32{}, nil
@@ -1011,9 +1110,6 @@ func (conn *ProtonConn) convertToArrayInt32(value interface{}) ([]int32, error) 
 	return result, nil
 }
 func (conn *ProtonConn) convertToArrayInt64(value interface{}) ([]int64, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []int64{}, nil
@@ -1033,9 +1129,6 @@ func (conn *ProtonConn) convertToArrayInt64(value interface{}) ([]int64, error) 
 	return result, nil
 }
 func (conn *ProtonConn) convertToArrayUint8(value interface{}) ([]uint8, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []uint8{}, nil
@@ -1055,9 +1148,6 @@ func (conn *ProtonConn) convertToArrayUint8(value interface{}) ([]uint8, error) 
 	return result, nil
 }
 func (conn *ProtonConn) convertToArrayUint16(value interface{}) ([]uint16, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []uint16{}, nil
@@ -1077,9 +1167,6 @@ func (conn *ProtonConn) convertToArrayUint16(value interface{}) ([]uint16, error
 	return result, nil
 }
 func (conn *ProtonConn) convertToArrayUint32(value interface{}) ([]uint32, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []uint32{}, nil
@@ -1100,9 +1187,6 @@ func (conn *ProtonConn) convertToArrayUint32(value interface{}) ([]uint32, error
 }
 
 func (conn *ProtonConn) convertToArrayUint64(value interface{}) ([]uint64, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []uint64{}, nil
@@ -1123,9 +1207,6 @@ func (conn *ProtonConn) convertToArrayUint64(value interface{}) ([]uint64, error
 }
 
 func (conn *ProtonConn) convertToArrayFloat32(value interface{}) ([]float32, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []float32{}, nil
@@ -1145,24 +1226,14 @@ func (conn *ProtonConn) convertToArrayFloat32(value interface{}) ([]float32, err
 	return result, nil
 }
 func (conn *ProtonConn) convertToArrayFloat64(value interface{}) ([]float64, error) {
-	if value == nil {
-		g.Info("empty arrayfloat64 if value == nil")
-		return []float64{}, nil
-	}
 
 	if value == "" {
-		g.Info("empty arrayfloat64 if value == \"\"")
 		return []float64{}, nil
 	}
 
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
-	}
-
-	if len(str) == 0 {
-		g.Info("empty arrayfloat64 if len(str) == 0")
-		return []float64{}, nil
 	}
 
 	var result []float64
@@ -1175,9 +1246,6 @@ func (conn *ProtonConn) convertToArrayFloat64(value interface{}) ([]float64, err
 }
 
 func (conn *ProtonConn) convertToArrayBool(value interface{}) ([]bool, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return []bool{}, nil
@@ -1199,9 +1267,6 @@ func (conn *ProtonConn) convertToArrayBool(value interface{}) ([]bool, error) {
 
 // Map types
 func (conn *ProtonConn) convertToMapStringUint64(value interface{}) (map[string]uint64, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string]uint64{}, nil
@@ -1222,9 +1287,6 @@ func (conn *ProtonConn) convertToMapStringUint64(value interface{}) (map[string]
 }
 
 func (conn *ProtonConn) convertToMapStringUint32(value interface{}) (map[string]uint32, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string]uint32{}, nil
@@ -1245,9 +1307,6 @@ func (conn *ProtonConn) convertToMapStringUint32(value interface{}) (map[string]
 }
 
 func (conn *ProtonConn) convertToMapStringInt32(value interface{}) (map[string]int32, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string]int32{}, nil
@@ -1268,9 +1327,6 @@ func (conn *ProtonConn) convertToMapStringInt32(value interface{}) (map[string]i
 }
 
 func (conn *ProtonConn) convertToMapStringInt64(value interface{}) (map[string]int64, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string]int64{}, nil
@@ -1291,9 +1347,6 @@ func (conn *ProtonConn) convertToMapStringInt64(value interface{}) (map[string]i
 }
 
 func (conn *ProtonConn) convertToMapStringFloat64(value interface{}) (map[string]float64, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string]float64{}, nil
@@ -1314,9 +1367,6 @@ func (conn *ProtonConn) convertToMapStringFloat64(value interface{}) (map[string
 }
 
 func (conn *ProtonConn) convertToMapStringFloat32(value interface{}) (map[string]float32, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string]float32{}, nil
@@ -1337,9 +1387,6 @@ func (conn *ProtonConn) convertToMapStringFloat32(value interface{}) (map[string
 }
 
 func (conn *ProtonConn) convertToMapInt32String(value interface{}) (map[int32]string, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[int32]string{}, nil
@@ -1360,9 +1407,6 @@ func (conn *ProtonConn) convertToMapInt32String(value interface{}) (map[int32]st
 }
 
 func (conn *ProtonConn) convertToMapInt64String(value interface{}) (map[int64]string, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[int64]string{}, nil
@@ -1383,9 +1427,6 @@ func (conn *ProtonConn) convertToMapInt64String(value interface{}) (map[int64]st
 }
 
 func (conn *ProtonConn) convertToMapStringArrayString(value interface{}) (map[string][]string, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string][]string{}, nil
@@ -1406,9 +1447,6 @@ func (conn *ProtonConn) convertToMapStringArrayString(value interface{}) (map[st
 }
 
 func (conn *ProtonConn) convertToMapStringString(value interface{}) (map[string]string, error) {
-	if value == nil {
-		return nil, nil
-	}
 
 	if value == "" {
 		return map[string]string{}, nil

--- a/core/dbio/database/database_proton.go
+++ b/core/dbio/database/database_proton.go
@@ -925,6 +925,10 @@ func (conn *ProtonConn) convertToArrayString(value interface{}) ([]string, error
 		return nil, nil
 	}
 
+	if value == "" {
+		return []string{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -942,6 +946,10 @@ func (conn *ProtonConn) convertToArrayString(value interface{}) ([]string, error
 func (conn *ProtonConn) convertToArrayInt8(value interface{}) ([]int8, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return []int8{}, nil
 	}
 
 	str, ok := value.(string)
@@ -963,6 +971,10 @@ func (conn *ProtonConn) convertToArrayInt16(value interface{}) ([]int16, error) 
 		return nil, nil
 	}
 
+	if value == "" {
+		return []int16{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -979,6 +991,10 @@ func (conn *ProtonConn) convertToArrayInt16(value interface{}) ([]int16, error) 
 func (conn *ProtonConn) convertToArrayInt32(value interface{}) ([]int32, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return []int32{}, nil
 	}
 
 	str, ok := value.(string)
@@ -999,6 +1015,10 @@ func (conn *ProtonConn) convertToArrayInt64(value interface{}) ([]int64, error) 
 		return nil, nil
 	}
 
+	if value == "" {
+		return []int64{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1015,6 +1035,10 @@ func (conn *ProtonConn) convertToArrayInt64(value interface{}) ([]int64, error) 
 func (conn *ProtonConn) convertToArrayUint8(value interface{}) ([]uint8, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return []uint8{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1035,6 +1059,10 @@ func (conn *ProtonConn) convertToArrayUint16(value interface{}) ([]uint16, error
 		return nil, nil
 	}
 
+	if value == "" {
+		return []uint16{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1051,6 +1079,10 @@ func (conn *ProtonConn) convertToArrayUint16(value interface{}) ([]uint16, error
 func (conn *ProtonConn) convertToArrayUint32(value interface{}) ([]uint32, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return []uint32{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1072,6 +1104,10 @@ func (conn *ProtonConn) convertToArrayUint64(value interface{}) ([]uint64, error
 		return nil, nil
 	}
 
+	if value == "" {
+		return []uint64{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1089,6 +1125,10 @@ func (conn *ProtonConn) convertToArrayUint64(value interface{}) ([]uint64, error
 func (conn *ProtonConn) convertToArrayFloat32(value interface{}) ([]float32, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return []float32{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1109,6 +1149,10 @@ func (conn *ProtonConn) convertToArrayFloat64(value interface{}) ([]float64, err
 		return nil, nil
 	}
 
+	if value == "" {
+		return []float64{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1126,6 +1170,10 @@ func (conn *ProtonConn) convertToArrayFloat64(value interface{}) ([]float64, err
 func (conn *ProtonConn) convertToArrayBool(value interface{}) ([]bool, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return []bool{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1148,6 +1196,10 @@ func (conn *ProtonConn) convertToMapStringUint64(value interface{}) (map[string]
 		return nil, nil
 	}
 
+	if value == "" {
+		return map[string]uint64{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1165,6 +1217,10 @@ func (conn *ProtonConn) convertToMapStringUint64(value interface{}) (map[string]
 func (conn *ProtonConn) convertToMapStringUint32(value interface{}) (map[string]uint32, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return map[string]uint32{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1186,6 +1242,10 @@ func (conn *ProtonConn) convertToMapStringInt32(value interface{}) (map[string]i
 		return nil, nil
 	}
 
+	if value == "" {
+		return map[string]int32{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1203,6 +1263,10 @@ func (conn *ProtonConn) convertToMapStringInt32(value interface{}) (map[string]i
 func (conn *ProtonConn) convertToMapStringInt64(value interface{}) (map[string]int64, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return map[string]int64{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1224,6 +1288,10 @@ func (conn *ProtonConn) convertToMapStringFloat64(value interface{}) (map[string
 		return nil, nil
 	}
 
+	if value == "" {
+		return map[string]float64{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1241,6 +1309,10 @@ func (conn *ProtonConn) convertToMapStringFloat64(value interface{}) (map[string
 func (conn *ProtonConn) convertToMapStringFloat32(value interface{}) (map[string]float32, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return map[string]float32{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1262,6 +1334,10 @@ func (conn *ProtonConn) convertToMapInt32String(value interface{}) (map[int32]st
 		return nil, nil
 	}
 
+	if value == "" {
+		return map[int32]string{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1279,6 +1355,10 @@ func (conn *ProtonConn) convertToMapInt32String(value interface{}) (map[int32]st
 func (conn *ProtonConn) convertToMapInt64String(value interface{}) (map[int64]string, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return map[int64]string{}, nil
 	}
 
 	str, ok := value.(string)
@@ -1300,6 +1380,10 @@ func (conn *ProtonConn) convertToMapStringArrayString(value interface{}) (map[st
 		return nil, nil
 	}
 
+	if value == "" {
+		return map[string][]string{}, nil
+	}
+
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
@@ -1317,6 +1401,10 @@ func (conn *ProtonConn) convertToMapStringArrayString(value interface{}) (map[st
 func (conn *ProtonConn) convertToMapStringString(value interface{}) (map[string]string, error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	if value == "" {
+		return map[string]string{}, nil
 	}
 
 	str, ok := value.(string)

--- a/core/dbio/database/database_proton.go
+++ b/core/dbio/database/database_proton.go
@@ -1146,16 +1146,23 @@ func (conn *ProtonConn) convertToArrayFloat32(value interface{}) ([]float32, err
 }
 func (conn *ProtonConn) convertToArrayFloat64(value interface{}) ([]float64, error) {
 	if value == nil {
-		return nil, nil
+		g.Info("empty arrayfloat64 if value == nil")
+		return []float64{}, nil
 	}
 
 	if value == "" {
+		g.Info("empty arrayfloat64 if value == \"\"")
 		return []float64{}, nil
 	}
 
 	str, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected string, got %T", value)
+	}
+
+	if len(str) == 0 {
+		g.Info("empty arrayfloat64 if len(str) == 0")
+		return []float64{}, nil
 	}
 
 	var result []float64

--- a/core/dbio/database/database_proton.go
+++ b/core/dbio/database/database_proton.go
@@ -328,10 +328,14 @@ func (conn *ProtonConn) processBatch(tableFName string, table Table, batch *iop.
 
 	for i, col := range batch.Columns {
 		dbType := strings.ToLower(col.DbType)
-		dbType = strings.TrimPrefix(dbType, "low_cardinality(")
-		dbType = strings.TrimPrefix(dbType, "nullable(")
-
-		dbType = strings.TrimSuffix(dbType, ")")
+		if strings.HasPrefix(dbType, "nullable(") {
+			dbType = strings.TrimPrefix(dbType, "nullable(")
+			dbType = strings.TrimSuffix(dbType, ")")
+		}
+		if strings.HasPrefix(dbType, "low_cardinality(") {
+			dbType = strings.TrimPrefix(dbType, "low_cardinality(")
+			dbType = strings.TrimSuffix(dbType, ")")
+		}
 
 		switch dbType {
 		case "int8":

--- a/core/dbio/dbio_types.go
+++ b/core/dbio/dbio_types.go
@@ -161,6 +161,14 @@ func (t Type) DBNameUpperCase() bool {
 	return g.In(t, TypeDbOracle, TypeDbSnowflake)
 }
 
+// timeplus@yokofly
+// DBNameCaseSensitive returns true if case sensitive
+// turn activate with clickhouse to fix the old issue https://github.com/slingdata-io/sling-cli/issues/417
+func (t Type) DBNameCaseSensitive() bool {
+	return t == TypeDbProton
+	// return g.In(t, TypeDbClickhouse, TypeDbProton)
+}
+
 // Kind returns the kind of connection
 func (t Type) Kind() Kind {
 	switch t {

--- a/core/dbio/dbio_types.go
+++ b/core/dbio/dbio_types.go
@@ -474,7 +474,9 @@ func (t Type) Quote(field string, normalize ...bool) string {
 	template, _ := t.Template()
 	// always normalize if case is uniform. Why would you quote and not normalize?
 	if !hasVariedCase(field) && Normalize {
-		if g.In(t, TypeDbOracle, TypeDbSnowflake) {
+		if t.DBNameCaseSensitive() {
+			// timeplus@yokofly
+		} else if g.In(t, TypeDbOracle, TypeDbSnowflake) {
 			field = strings.ToUpper(field)
 		} else {
 			field = strings.ToLower(field)

--- a/core/dbio/iop/csv.go
+++ b/core/dbio/iop/csv.go
@@ -43,7 +43,6 @@ type CSV struct {
 func CleanHeaderRow(header []string) []string {
 	// replace any other chars than regex expression
 	regexAllow := *regexp.MustCompile(`[^a-zA-Z0-9_]`)
-	fieldMap := map[string]string{}
 
 	transformer := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
 	for i, field := range header {
@@ -64,16 +63,9 @@ func CleanHeaderRow(header []string) []string {
 			field = "col"
 		}
 
-		// avoid duplicates
-		j := 1
-		newField := field
-		for fieldMap[newField] != "" {
-			newField = g.F("%s%d", field, j)
-			j++
-		}
-
-		fieldMap[newField] = field
-		header[i] = strings.ToLower(newField)
+		header[i] = field
+		/// timeplus@yokofly, see issue https://github.com/slingdata-io/sling-cli/issues/417
+		/// we need to preserve the original case for proton
 	}
 
 	return header

--- a/core/dbio/iop/datastream.go
+++ b/core/dbio/iop/datastream.go
@@ -1207,10 +1207,10 @@ func (ds *Datastream) ConsumeCsvReaderChl(readerChn chan *ReaderReady) (err erro
 				row0 = CleanHeaderRow(row0)
 
 				// some files may have new columns
-				fm := it.ds.Columns.FieldMap(true)
+				fm := it.ds.Columns.FieldMap(false)
 				toAdd := Columns{}
 				for _, name := range row0 {
-					if _, ok := fm[strings.ToLower(name)]; !ok {
+					if _, ok := fm[name]; !ok {
 						// field is not found, so we need to add
 						toAdd = append(toAdd, Column{Name: name, Type: StringType, Position: len(it.ds.Columns) + 1})
 					}
@@ -1223,10 +1223,10 @@ func (ds *Datastream) ConsumeCsvReaderChl(readerChn chan *ReaderReady) (err erro
 
 				// set column mapping if in different order
 				if g.Marshal(row0) != g.Marshal(it.ds.Columns.Names()) {
-					fm := it.ds.Columns.FieldMap(true)
+					fm := it.ds.Columns.FieldMap(false)
 					colMap = map[int]int{}
 					for incorrectI, name := range row0 {
-						colMap[incorrectI] = fm[strings.ToLower(name)]
+						colMap[incorrectI] = fm[name]
 					}
 				} else {
 					colMap = nil
@@ -2025,7 +2025,7 @@ func (ds *Datastream) NewCsvReaderChnl(rowLimit int, bytesLimit int64) (readerCh
 			}
 
 			if ds.config.Header {
-				bw, err := w.Write(batch.Columns.Names(true, true))
+				bw, err := w.Write(batch.Columns.Names(false, true))
 				tbw = tbw + cast.ToInt64(bw)
 				if err != nil {
 					err = g.Error(err, "error writing header")
@@ -2480,7 +2480,7 @@ func (ds *Datastream) NewCsvReader(rowLimit int, bytesLimit int64) *io.PipeReade
 		}
 
 		if ds.config.Header {
-			bw, err := w.Write(batch.Columns.Names(true, true))
+			bw, err := w.Write(batch.Columns.Names(false, true))
 			tbw = tbw + cast.ToInt64(bw)
 			if err != nil {
 				ds.Context.CaptureErr(g.Error(err, "error writing header"))

--- a/core/dbio/iop/datatype.go
+++ b/core/dbio/iop/datatype.go
@@ -596,6 +596,15 @@ func (cols Columns) GetColumn(name string) *Column {
 	return colsMap[strings.ToLower(name)]
 }
 
+// GetColumnWithOriginalCase returns the matched Col
+func (cols Columns) GetColumnWithOriginalCase(name string) *Column {
+	colsMap := map[string]*Column{}
+	for _, col := range cols {
+		colsMap[col.Name] = &col
+	}
+	return colsMap[name]
+}
+
 func (cols Columns) Merge(newCols Columns, overwrite bool) (col2 Columns, added schemaChg, changed []schemaChg) {
 	added = schemaChg{Added: true}
 

--- a/core/dbio/iop/datatype.go
+++ b/core/dbio/iop/datatype.go
@@ -445,11 +445,11 @@ func (cols Columns) MakeShaper(tgtColumns Columns) (shaper *Shaper, err error) {
 	}
 
 	// determine diff, and match order of target columns
-	tgtColNames := tgtColumns.Names(true)
+	tgtColNames := tgtColumns.Names(false)
 	diffCols := len(tgtColumns) != len(srcColumns)
 	colMap := map[int]int{}
 	for s, col := range srcColumns {
-		t := lo.IndexOf(tgtColNames, strings.ToLower(col.Name))
+		t := lo.IndexOf(tgtColNames, col.Name)
 		if t == -1 {
 			err = g.Error("column %s not found in target columns", col.Name)
 			return
@@ -608,9 +608,9 @@ func (cols Columns) GetColumnWithOriginalCase(name string) *Column {
 func (cols Columns) Merge(newCols Columns, overwrite bool) (col2 Columns, added schemaChg, changed []schemaChg) {
 	added = schemaChg{Added: true}
 
-	existingIndexMap := cols.FieldMap(true)
+	existingIndexMap := cols.FieldMap(false)
 	for _, newCol := range newCols {
-		key := strings.ToLower(newCol.Name)
+		key := newCol.Name
 		if i, ok := existingIndexMap[key]; ok {
 			col := cols[i]
 			if overwrite {
@@ -656,10 +656,9 @@ func (cols Columns) IsSimilarTo(otherCols Columns) bool {
 		return false
 	}
 
-	otherColsMap := cols.FieldMap(true)
+	otherColsMap := cols.FieldMap(false)
 	for _, col := range cols {
-		colName := strings.ToLower(col.Name)
-		if _, found := otherColsMap[colName]; !found {
+		if _, found := otherColsMap[col.Name]; !found {
 			return false
 		}
 	}

--- a/core/dbio/templates/proton.yaml
+++ b/core/dbio/templates/proton.yaml
@@ -45,6 +45,7 @@ metadata:
     from system.columns
     where database = '{schema}'
       and table = '{table}'
+      and default_kind != 'ALIAS'
     order by position
 
   primary_keys: |

--- a/core/sling/config.go
+++ b/core/sling/config.go
@@ -157,7 +157,7 @@ func (cfg *Config) SetDefault() {
 		cfg.Source.Options.MaxDecimals = g.Int(11)
 		cfg.Target.Options.MaxDecimals = g.Int(11)
 		if cfg.Target.Options.BatchLimit == nil {
-			cfg.Target.Options.BatchLimit = g.Int64(5000)
+			cfg.Target.Options.BatchLimit = g.Int64(50000)
 		}
 	}
 


### PR DESCRIPTION
PR intends to:
1. conf: set a larger batch limit when writing to target proton
2. enhance the csv import (handle some edge case like `create stream v(Hot int, hOT int)` )  
<details> <summary> more internal see https://github.com/slingdata-io/sling-cli/issues/417 </summary>

```
fix #34 

The old code intends to normalize every column to lower or upper case. 
This makes it difficult if we create a table with two columns that are almost the same:

create stream v(id int, Id float)

also because writing to csv the header is lowercase, we need to convert it to keep the old name.


the side effect: 
when importing a csv from other systems instead sling prob has an issue.
and I was thinking of the current PR hard code in many places,  need some time to prepare before sending it upstream.
```

</details>

3. database_proton.go: refine the insert logic, to make [nan] in float can be treated as NULL.

4. change proton template yaml: skip ALIAS columns. `create stream v(id int, l int ALIAS id)`  this table only one column id

