### PR TITLE
fix: update timestamp layout and parsing method in Proton configuration

### DIFF
--- a/core/dbio/templates/proton.yaml
+++ b/core/dbio/templates/proton.yaml
@@ -251,5 +251,5 @@ variable:
   bool_as: string
   error_filter_table_exists: already
   quote_char: "`"
-  timestamp_layout: "2006-01-02 15:04:05.000000 +00"
-  timestamp_layout_str: to_time('{value}')
+  timestamp_layout: "2006-01-02 15:04:05.000000000 -07"
+  timestamp_layout_str: parse_datetime64_best_effort_or_null('{value}')


### PR DESCRIPTION
fix #46 

the issue is when incremental mode insert, sling try directly compared with utc(csv) with utc+8(proton)
and the compare is called with `to_time` this is not smart enough to find the timezone.

repro:
1. create 2 streams in proton
```
CREATE STREAM src
             (
               `id` int64,
               `_tp_time` datetime64(3, 'Asia/Shanghai') DEFAULT now64(3, 'Asia/Shanghai') CODEC(DoubleDelta, LZ4)
             );

CREATE STREAM tgt
             (
               `id` int64,
               `_tp_time` datetime64(3, 'Asia/Shanghai') DEFAULT now64(3, 'Asia/Shanghai') CODEC(DoubleDelta, LZ4)
             );
```

2. insert older record 
```
insert into src(id, _tp_time) values(1, '2025-07-18 22:00:00');
```

3. proton => csv => proton 
```
./sling  run --src-conn LOCAL --src-stream "src" --tgt-conn FILE --tgt-object "old.csv" --mode incremental --update-key _tp_time -d

./sling  run --src-conn FILE --src-stream "old.csv" --tgt-conn LOCAL --tgt-object "tgt" --mode incremental --update-key _tp_time -d
````

4. insert  new record(the gap between newer and older is less than 8 hours) 
```
insert into src(id, _tp_time) values(2, '2025-07-19 05:00:00');
```

5. proton => csv => proton
```
./sling  run --src-conn LOCAL --src-stream "src" --tgt-conn FILE --tgt-object "new.csv" --mode incremental --update-key _tp_time -d

./sling  run --src-conn FILE --src-stream "new.csv" --tgt-conn LOCAL --tgt-object "tgt" --mode incremental --update-key _tp_time -d
```

6. verify the final count
```
select * from table(tgt) 
```
expected: get 2 rows
old sling: only get one row