### PR TITLE
Feature/issue 45 expose discover conns

### DIFF
--- a/cmd/sling/sling_conns.go
+++ b/cmd/sling/sling_conns.go
@@ -24,7 +24,7 @@ var (
 
 func discoverConnection(c *g.CliSC) error {
 	env.SetTelVal("task", g.Marshal(g.M("type", sling.ConnDiscover)))
-	
+
 	name := cast.ToString(c.Vals["name"])
 	if name == "" {
 		return g.Error("connection name is required")
@@ -95,7 +95,7 @@ func discoverConnection(c *g.CliSC) error {
 					g.Info("No tables found")
 					return nil
 				}
-				
+
 				// Match official output format with row numbers and database column
 				fields := []string{"#", "database", "schema", "name", "type"}
 				rows := make([][]interface{}, 0, len(tables))
@@ -124,7 +124,7 @@ func discoverConnection(c *g.CliSC) error {
 				g.Info("No files found")
 				return nil
 			}
-			
+
 			if showColumns {
 				// Show files with their columns
 				for _, node := range nodes {

--- a/core/dbio/connection/connection_discover.go
+++ b/core/dbio/connection/connection_discover.go
@@ -2,7 +2,6 @@ package connection
 
 import (
 	"context"
-	"sort"
 	"strings"
 	"time"
 
@@ -12,8 +11,6 @@ import (
 	"github.com/slingdata-io/sling-cli/core/dbio/database"
 	"github.com/slingdata-io/sling-cli/core/dbio/filesys"
 	"github.com/slingdata-io/sling-cli/core/dbio/iop"
-	"github.com/slingdata-io/sling-cli/core/env"
-	"github.com/spf13/cast"
 )
 
 func (c *Connection) Test() (ok bool, err error) {
@@ -177,7 +174,7 @@ func (c *Connection) Discover(opt *DiscoverOptions) (ok bool, nodes filesys.File
 			return ok, nodes, schemata, g.Error(err, "could not connect to %s", c.Name)
 		}
 		g.Debug("unfiltered nodes returned: %d", len(nodes))
-		if len(nodes) <= 10 {
+		if len(nodes) <= 20 {
 			g.Debug(g.Marshal(nodes.Paths()))
 		}
 
@@ -241,32 +238,6 @@ func (c *Connection) Discover(opt *DiscoverOptions) (ok bool, nodes filesys.File
 	}
 
 	ok = true
-
-	return
-}
-
-func EnvFileConnectionEntries(ef env.EnvFile, sourceName string) (entries ConnEntries, err error) {
-	m := g.M()
-	if err = g.JSONConvert(ef, &m); err != nil {
-		return entries, g.Error(err)
-	}
-
-	connsMap := map[string]ConnEntry{}
-	profileConns, err := ReadConnections(m)
-	for _, conn := range profileConns {
-		c := ConnEntry{
-			Name:        strings.ToUpper(conn.Info().Name),
-			Description: conn.Type.NameLong(),
-			Source:      sourceName,
-			Connection:  conn,
-		}
-		connsMap[c.Name] = c
-	}
-
-	entries = lo.Values(connsMap)
-	sort.Slice(entries, func(i, j int) bool {
-		return cast.ToString(entries[i].Name) < cast.ToString(entries[j].Name)
-	})
 
 	return
 }


### PR DESCRIPTION
fix #45 


```
➜  sling-cli git:(feature/issue-45-expose-discover-conns) ✗ ./sling conns discover PROTON  -d2
sling - An Extract-Load tool | https://slingdata.io/
Slings data from a data source to a data target.
Version dev

  Usage:
    sling [clean-partitions|conns|run]

  Subcommands:
    clean-partitions   Clean daily data for Timeplusd (Proton) tables
    conns              Manage and interact with local connections
    run                Execute a run

  Flags:
       --version   Displays the program version string.
    -h --help      Displays help with available flag, subcommand, and positional value parameters.

Expected a following arg for flag d2, but it did not exist.
➜  sling-cli git:(feature/issue-45-expose-discover-conns) ✗ ./sling conns discover PROTON
11:57PM WRN could not parse DEBUGINFOD_URLS: could not parse provided credentials / url
+---+----------+---------+-----------------+-------+
| # | DATABASE | SCHEMA  | NAME            | TYPE  |
+---+----------+---------+-----------------+-------+
| 1 | default  | default | test38_rd       | table |
| 2 | default  | default | test38_target1  | table |
| 3 | default  | default | v               | table |
| 4 | default  | default | mirror_v        | table |
| 5 | default  | default | mirror_v_sorted | table |
+---+----------+---------+-----------------+-------+
➜  sling-cli git:(feature/issue-45-expose-discover-conns) ✗ DEBUG=1 ./sling conns discover PROTON
11:58PM WRN could not parse DEBUGINFOD_URLS: could not parse provided credentials / url
11:58PM DBG opened "proton" connection (conn-proton-3WE)
11:58PM DBG database discover inputs: {"level":"table","pattern":"","schema":"","table":""}
11:58PM DBG unfiltered table records returned: 5
11:58PM DBG ["default.default.mirror_v","default.default.mirror_v_sorted","default.default.test38_rd","default.default.test38_target1","default.default.v"]
+---+----------+---------+-----------------+-------+
| # | DATABASE | SCHEMA  | NAME            | TYPE  |
+---+----------+---------+-----------------+-------+
| 1 | default  | default | test38_target1  | table |
| 2 | default  | default | v               | table |
| 3 | default  | default | mirror_v        | table |
| 4 | default  | default | mirror_v_sorted | table |
| 5 | default  | default | test38_rd       | table |
+---+----------+---------+-----------------+-------+
➜  sling-cli git:(feature/issue-45-expose-discover-conns) ✗
```