### PR TITLE
fix(proton): eliminate float64 precision loss and add column order guard

### DIFF
--- a/core/dbio/database/database_proton.go
+++ b/core/dbio/database/database_proton.go
@@ -796,6 +796,16 @@ func (conn *ProtonConn) BulkImportStreamColumnar(tableFName string, ds *iop.Data
 	for batch := range ds.BatchChan {
 		batchCount++
 
+		// Verify batch column order matches insFields. The columnar buffer
+		// uses positional indexing (row[i] → col[i]), so a column order
+		// mismatch would silently misroute values. This can happen with
+		// multi-file imports where CSVs have different column orders.
+		if batchCount == 1 || batch.ColumnsChanged() {
+			if err := verifyColumnOrder(batch.Columns, insFields); err != nil {
+				return count, g.Error(err, "columnar batch %d: %s", batchCount, err)
+			}
+		}
+
 		// Drain rows into columnar buffer
 		cb.Reset()
 		for row := range batch.Rows {
@@ -893,6 +903,23 @@ func (conn *ProtonConn) BulkImportFlowColumnar(tableFName string, df *iop.Datafl
 
 	df.Context.Wg.Write.Wait()
 	return count, df.Err()
+}
+
+// verifyColumnOrder checks that batch columns match insFields in both
+// name and position. The columnar buffer uses positional indexing
+// (row[i] → col[i]), so any mismatch would silently corrupt data.
+func verifyColumnOrder(batchCols iop.Columns, insFields iop.Columns) error {
+	// insFields may have fewer columns than the batch if metadata columns
+	// were added (e.g. _loaded_at). Only check the insFields range.
+	for i, ins := range insFields {
+		if i >= len(batchCols) {
+			return g.Error("batch has %d columns, expected at least %d", len(batchCols), len(insFields))
+		}
+		if !strings.EqualFold(batchCols[i].Name, ins.Name) {
+			return g.Error("column order mismatch at position %d: batch has %q, target expects %q", i, batchCols[i].Name, ins.Name)
+		}
+	}
+	return nil
 }
 
 // ExecContext runs a sql query with context, returns `error`

--- a/core/dbio/database/database_proton_columnar_test.go
+++ b/core/dbio/database/database_proton_columnar_test.go
@@ -492,3 +492,62 @@ func TestColBuffer_AllIntWidths(t *testing.T) {
 		assert.NotNil(t, c.typedSlice())
 	}
 }
+
+// ─── verifyColumnOrder ─────────────────────────────────────────────────
+
+func TestVerifyColumnOrder(t *testing.T) {
+	insFields := iop.Columns{
+		{Name: "id", DbType: "int32"},
+		{Name: "name", DbType: "string"},
+		{Name: "value", DbType: "float64"},
+	}
+
+	t.Run("matching order", func(t *testing.T) {
+		batch := iop.Columns{
+			{Name: "id"}, {Name: "name"}, {Name: "value"},
+		}
+		assert.NoError(t, verifyColumnOrder(batch, insFields))
+	})
+
+	t.Run("case insensitive match", func(t *testing.T) {
+		batch := iop.Columns{
+			{Name: "ID"}, {Name: "Name"}, {Name: "VALUE"},
+		}
+		assert.NoError(t, verifyColumnOrder(batch, insFields))
+	})
+
+	t.Run("extra batch columns OK", func(t *testing.T) {
+		// Metadata columns like _loaded_at may be appended
+		batch := iop.Columns{
+			{Name: "id"}, {Name: "name"}, {Name: "value"}, {Name: "_loaded_at"},
+		}
+		assert.NoError(t, verifyColumnOrder(batch, insFields))
+	})
+
+	t.Run("wrong order detected", func(t *testing.T) {
+		batch := iop.Columns{
+			{Name: "value"}, {Name: "name"}, {Name: "id"},
+		}
+		err := verifyColumnOrder(batch, insFields)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "column order mismatch")
+	})
+
+	t.Run("swapped pair detected", func(t *testing.T) {
+		batch := iop.Columns{
+			{Name: "id"}, {Name: "value"}, {Name: "name"},
+		}
+		err := verifyColumnOrder(batch, insFields)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "position 1")
+	})
+
+	t.Run("batch too short", func(t *testing.T) {
+		batch := iop.Columns{
+			{Name: "id"}, {Name: "name"},
+		}
+		err := verifyColumnOrder(batch, insFields)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected at least")
+	})
+}

--- a/core/dbio/iop/cast_plan_sync_test.go
+++ b/core/dbio/iop/cast_plan_sync_test.go
@@ -1,0 +1,290 @@
+package iop
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBufferReplayCastPlanSync verifies that the buffer-replay goroutine
+// waits for the target cast plan before processing rows. Without the fix,
+// the first buffered rows would race through CastRow (which applies
+// max_decimals truncation) instead of CastRowToTarget.
+//
+// The test simulates the real flow:
+//   1. Create a datastream with a CSV-like iterator
+//   2. Call Start() which buffers rows and starts the replay goroutine
+//   3. The goroutine should wait for castPlanReady/pauseChan
+//   4. Set the target cast plan (simulating ApplyTargetCastPlan)
+//   5. Signal castPlanReady
+//   6. Verify ALL rows (including the first) went through CastRowToTarget
+func TestBufferReplayCastPlanSync(t *testing.T) {
+	// Create columns matching a float64 target schema
+	cols := Columns{
+		{Name: "id", Type: IntegerType, Position: 1, DbType: "int32"},
+		{Name: "val", Type: FloatType, Position: 2, DbType: "float64"},
+	}
+
+	// Track which cast path each row takes
+	var mu sync.Mutex
+	castPaths := map[int]string{} // row index → "fast" or "slow"
+
+	// Create datastream with a simple iterator that produces string rows
+	// (simulating CSV input)
+	rows := [][]any{
+		{"1", "6.75484118612095"},
+		{"2", "9.87654321098765"},
+		{"3", "3.14159265358979"},
+	}
+	rowIdx := 0
+	ds := NewDatastreamContext(context.Background(), cols)
+	ds.Sp.Config.MaxDecimals = 11
+	ds.Sp.Config.maxDecimalsFormat = "%.11f"
+
+	nextFunc := func(it *Iterator) bool {
+		if rowIdx >= len(rows) {
+			return false
+		}
+		it.Row = rows[rowIdx]
+		rowIdx++
+		return true
+	}
+	ds.it = ds.NewIterator(cols, nextFunc)
+
+	// Start the datastream — this buffers all 3 rows (SampleSize > 3),
+	// infers types, calls SetReady, and starts the replay goroutine.
+	// The goroutine should block on castPlanReady before processing.
+	err := ds.Start()
+	require.NoError(t, err)
+
+	// Wait for the stream to be ready
+	err = ds.WaitReady()
+	require.NoError(t, err)
+
+	// At this point, the goroutine is started but should be waiting
+	// on castPlanReady or pauseChan before processing buffer rows.
+	// Simulate the dataflow adopting this stream.
+	df := NewDataflow()
+	ds.df = df
+
+	// Now set the target cast plan (simulating ApplyTargetCastPlan)
+	targetCols := Columns{
+		{Name: "id", Type: IntegerType, Position: 1, DbType: "int32"},
+		{Name: "val", Type: FloatType, Position: 2, DbType: "float64"},
+	}
+	ds.Sp.SetTargetCastPlan(targetCols)
+
+	// Signal that the plan is ready — this unblocks the goroutine
+	ds.SignalCastPlanReady()
+
+	// Collect all rows from batches and check that the plan was used.
+	// We verify by checking the types: CastRowToTarget returns typed
+	// values (float64), while CastRow with max_decimals returns strings.
+	timeout := time.After(5 * time.Second)
+	collected := 0
+	for collected < len(rows) {
+		select {
+		case batch, ok := <-ds.BatchChan:
+			if !ok {
+				t.Fatal("BatchChan closed before all rows collected")
+			}
+			for row := range batch.Rows {
+				idx := collected
+				val := row[1]
+				mu.Lock()
+				switch val.(type) {
+				case float64:
+					castPaths[idx] = "fast"
+				case string:
+					castPaths[idx] = "slow"
+				default:
+					castPaths[idx] = fmt.Sprintf("unknown(%T)", val)
+				}
+				mu.Unlock()
+				collected++
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for rows, got %d/%d", collected, len(rows))
+		}
+	}
+
+	// ALL rows should have gone through the fast path (CastRowToTarget)
+	for i := 0; i < len(rows); i++ {
+		assert.Equal(t, "fast", castPaths[i],
+			"row %d should use CastRowToTarget (fast path), got %s", i, castPaths[i])
+	}
+}
+
+// TestBufferReplayPauseHandshake verifies that the buffer-replay goroutine
+// correctly handles the Pause/Unpause cycle that writeDirectly uses to set
+// the cast plan. This is the exact sequence that caused the original bug:
+//   1. Goroutine starts, waits on castPlanReady/pauseChan
+//   2. TryPause sends to pauseChan (simulating df.Pause())
+//   3. ApplyTargetCastPlan sets the plan + signals castPlanReady
+//   4. Unpause sends to unpauseChan
+//   5. Goroutine resumes and processes rows with the plan
+func TestBufferReplayPauseHandshake(t *testing.T) {
+	cols := Columns{
+		{Name: "id", Type: IntegerType, Position: 1, DbType: "int32"},
+		{Name: "val", Type: FloatType, Position: 2, DbType: "float64"},
+	}
+
+	rows := [][]any{
+		{"1", "1.23456789012345"},
+		{"2", "9.87654321098765"},
+	}
+	rowIdx := 0
+	ds := NewDatastreamContext(context.Background(), cols)
+	ds.Sp.Config.MaxDecimals = 11
+	ds.Sp.Config.maxDecimalsFormat = "%.11f"
+
+	nextFunc := func(it *Iterator) bool {
+		if rowIdx >= len(rows) {
+			return false
+		}
+		it.Row = rows[rowIdx]
+		rowIdx++
+		return true
+	}
+	ds.it = ds.NewIterator(cols, nextFunc)
+
+	err := ds.Start()
+	require.NoError(t, err)
+	err = ds.WaitReady()
+	require.NoError(t, err)
+
+	// Simulate PushStreamChan setting ds.df
+	df := NewDataflow()
+	ds.df = df
+
+	// Simulate df.Pause() — TryPause sends to pauseChan
+	paused := ds.TryPause()
+	require.True(t, paused, "TryPause should succeed while goroutine waits")
+
+	// Simulate ApplyTargetCastPlan
+	targetCols := Columns{
+		{Name: "id", Type: IntegerType, Position: 1, DbType: "int32"},
+		{Name: "val", Type: FloatType, Position: 2, DbType: "float64"},
+	}
+	ds.Sp.SetTargetCastPlan(targetCols)
+	ds.SignalCastPlanReady()
+
+	// Simulate Unpause — unblock the goroutine
+	ds.Unpause()
+
+	// Collect rows and verify they all used the fast path
+	timeout := time.After(5 * time.Second)
+	collected := 0
+	for collected < len(rows) {
+		select {
+		case batch, ok := <-ds.BatchChan:
+			if !ok {
+				t.Fatal("BatchChan closed before all rows collected")
+			}
+			for row := range batch.Rows {
+				val := row[1]
+				_, isFast := val.(float64)
+				assert.True(t, isFast,
+					"row %d: expected float64 (fast path), got %T = %v", collected, val, val)
+				collected++
+			}
+		case <-timeout:
+			t.Fatalf("timed out, got %d/%d rows", collected, len(rows))
+		}
+	}
+}
+
+// TestStandaloneStreamNoDeadlock verifies that standalone streams (no
+// dataflow, no PushStreamChan) still work correctly without blocking.
+// WaitReady (called by Collect) signals castPlanReady, unblocking the
+// buffer-replay goroutine deterministically — no timing heuristic.
+func TestStandaloneStreamNoDeadlock(t *testing.T) {
+	cols := Columns{
+		{Name: "id", Type: IntegerType, Position: 1},
+		{Name: "name", Type: StringType, Position: 2},
+	}
+
+	rows := [][]any{{"1", "alice"}, {"2", "bob"}}
+	rowIdx := 0
+	ds := NewDatastreamContext(context.Background(), cols)
+
+	nextFunc := func(it *Iterator) bool {
+		if rowIdx >= len(rows) {
+			return false
+		}
+		it.Row = rows[rowIdx]
+		rowIdx++
+		return true
+	}
+	ds.it = ds.NewIterator(cols, nextFunc)
+
+	err := ds.Start()
+	require.NoError(t, err)
+
+	// Collect without any dataflow — WaitReady signals castPlanReady,
+	// so this should complete almost instantly, not hang.
+	start := time.Now()
+	data, err := ds.Collect(0)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(data.Rows), "should collect all rows")
+	assert.Less(t, elapsed, 500*time.Millisecond, "should complete quickly (no timing heuristic)")
+}
+
+// TestSignalAllCastPlanReady verifies that SignalAllCastPlanReady unblocks
+// streams that don't have a target cast plan (non-Proton targets).
+func TestSignalAllCastPlanReady(t *testing.T) {
+	cols := Columns{
+		{Name: "id", Type: IntegerType, Position: 1},
+		{Name: "val", Type: StringType, Position: 2},
+	}
+
+	rows := [][]any{{"1", "hello"}, {"2", "world"}}
+	rowIdx := 0
+	ds := NewDatastreamContext(context.Background(), cols)
+
+	nextFunc := func(it *Iterator) bool {
+		if rowIdx >= len(rows) {
+			return false
+		}
+		it.Row = rows[rowIdx]
+		rowIdx++
+		return true
+	}
+	ds.it = ds.NewIterator(cols, nextFunc)
+
+	err := ds.Start()
+	require.NoError(t, err)
+	err = ds.WaitReady()
+	require.NoError(t, err)
+
+	// Simulate dataflow adoption without a cast plan (non-Proton target)
+	df := NewDataflow()
+	ds.df = df
+
+	// Signal without setting any plan — should still unblock
+	ds.SignalCastPlanReady()
+
+	timeout := time.After(5 * time.Second)
+	collected := 0
+	for collected < len(rows) {
+		select {
+		case batch, ok := <-ds.BatchChan:
+			if !ok {
+				t.Fatal("BatchChan closed")
+			}
+			for range batch.Rows {
+				collected++
+			}
+		case <-timeout:
+			t.Fatalf("timed out, got %d/%d rows", collected, len(rows))
+		}
+	}
+	assert.Equal(t, len(rows), collected)
+}

--- a/core/dbio/iop/dataflow.go
+++ b/core/dbio/iop/dataflow.go
@@ -112,8 +112,20 @@ func (df *Dataflow) ApplyTargetCastPlan(columns Columns) {
 	df.TargetCastColumns = columns
 	for _, ds := range df.Streams {
 		ds.Sp.SetTargetCastPlan(columns)
+		ds.SignalCastPlanReady()
 	}
 	df.mux.Unlock()
+}
+
+// SignalAllCastPlanReady signals all existing streams that cast plan
+// setup is complete (or not applicable). Called before Unpause to
+// unblock buffer-replay goroutines that are waiting for the plan.
+func (df *Dataflow) SignalAllCastPlanReady() {
+	df.mux.Lock()
+	defer df.mux.Unlock()
+	for _, ds := range df.Streams {
+		ds.SignalCastPlanReady()
+	}
 }
 
 // StreamConfig get the first Sp config
@@ -219,6 +231,11 @@ func (df *Dataflow) Unpause(exceptDs ...string) {
 	if df.Ready {
 		for _, ds := range df.Streams {
 			if !lo.Contains(exceptDs, ds.ID) {
+				// Signal cast plan ready before unpausing. This covers all
+				// write paths (database, file, stdout) uniformly — every path
+				// calls Unpause after setup is complete. For Proton targets,
+				// ApplyTargetCastPlan already signaled — sync.Once no-ops.
+				ds.SignalCastPlanReady()
 				ds.Unpause()
 			}
 		}
@@ -569,6 +586,18 @@ func (df *Dataflow) PushStreamChan(dsCh chan *Datastream) {
 		if ds.Err() != nil {
 			df.Context.CaptureErr(ds.Err())
 			return
+		}
+
+		// Set target cast plan early, before the stream's buffer-replay
+		// goroutine processes rows. This eliminates the race where the
+		// first rows go through the slower CastRow path (which applies
+		// max_decimals truncation) instead of CastRowToTarget.
+		// Only signal castPlanReady when the plan is actually set;
+		// for the first stream, TargetCastColumns may not be available
+		// yet and the signal will come from ApplyTargetCastPlan instead.
+		if len(df.TargetCastColumns) > 0 && !ds.Sp.HasTargetCastPlan() {
+			ds.Sp.SetTargetCastPlan(df.TargetCastColumns)
+			ds.SignalCastPlanReady()
 		}
 
 		select {

--- a/core/dbio/iop/datastream.go
+++ b/core/dbio/iop/datastream.go
@@ -67,6 +67,13 @@ type Datastream struct {
 	paused        bool
 	pauseChan     chan struct{}
 	unpauseChan   chan struct{}
+
+	// castPlanReady is closed when the target cast plan setup is complete
+	// (or confirmed not needed). The buffer-replay goroutine waits on this
+	// before processing rows, to avoid a race where the first rows go
+	// through the slower CastRow path (which applies max_decimals truncation).
+	castPlanReady chan struct{}
+	castPlanOnce  sync.Once
 }
 
 type schemaChg struct {
@@ -185,6 +192,7 @@ func NewDatastreamContext(ctx context.Context, columns Columns) (ds *Datastream)
 		schemaChgChan: make(chan schemaChg, 1000),
 		pauseChan:     make(chan struct{}),
 		unpauseChan:   make(chan struct{}),
+		castPlanReady: make(chan struct{}),
 	}
 	ds.Sp.ds = ds
 	ds.it = ds.NewIterator(columns, func(it *Iterator) bool { return false })
@@ -246,6 +254,12 @@ func (ds *Datastream) SetReady() {
 		ds.Ready = true
 		go func() { ds.readyChn <- struct{}{} }()
 	}
+}
+
+// SignalCastPlanReady signals that the target cast plan has been set
+// (or is confirmed not needed). Safe to call multiple times.
+func (ds *Datastream) SignalCastPlanReady() {
+	ds.castPlanOnce.Do(func() { close(ds.castPlanReady) })
 }
 
 // SetEmpty sets the ds.Rows channel as empty
@@ -340,11 +354,15 @@ func (ds *Datastream) IsClosed() bool {
 // WaitReady waits until datastream is ready
 func (ds *Datastream) WaitReady() error {
 	if ds.Ready {
+		// Signal castPlanReady for standalone consumers (e.g. Collect)
+		// that don't go through PushStreamChan/ApplyTargetCastPlan.
+		ds.SignalCastPlanReady()
 		return ds.Context.Err()
 	}
 
 	select {
 	case <-ds.readyChn:
+		ds.SignalCastPlanReady()
 		return ds.Context.Err()
 	case <-ds.Context.Ctx.Done():
 		return ds.Context.Err()
@@ -856,6 +874,36 @@ loop:
 				ds.Context.CaptureErr(g.Error(ds.it.Context.Err(), "error during iteration"))
 			}
 		}()
+
+		// Wait for target cast plan before replaying buffer rows.
+		// This prevents a race where the first buffer rows go through
+		// CastRow (which applies max_decimals truncation) instead of
+		// CastRowToTarget. We must also handle pauseChan here because
+		// the dataflow's Pause/Unpause cycle (which sets the plan)
+		// needs the goroutine to be responsive to pause signals.
+		//
+		// The loop handles Pause() retry: if Pause() fails to pause all
+		// streams atomically, it unpauses and retries. The goroutine must
+		// loop back and wait again rather than proceeding without the plan.
+		//
+		// Signaled by: ApplyTargetCastPlan, Unpause, WriteToFile,
+		//   PushStreamChan (subsequent streams), or WaitReady (standalone).
+		if ds.it.dsBufferI >= 0 && len(ds.Buffer) > 0 {
+			for {
+				select {
+				case <-ds.castPlanReady:
+					goto bufferReplayReady
+				case <-ds.pauseChan:
+					// Paused by dataflow — wait for unpause, then re-check.
+					// Pause() retry may unpause without setting the plan.
+					<-ds.unpauseChan
+					continue
+				case <-ds.Context.Ctx.Done():
+					return
+				}
+			}
+		bufferReplayReady:
+		}
 
 	loop:
 		for ds.it.next() {

--- a/core/sling/task_run_write.go
+++ b/core/sling/task_run_write.go
@@ -35,6 +35,10 @@ func (t *TaskExecution) WriteToFile(cfg *Config, df *iop.Dataflow) (cnt uint64, 
 	defer t.PBar.Finish()
 	setStage("5 - load-into-final")
 
+	// File targets have no Pause/Unpause cycle, so unblock
+	// buffer-replay goroutines that are waiting for the cast plan.
+	df.SignalAllCastPlanReady()
+
 	if uri := cfg.TgtConn.URL(); uri != "" {
 		dateMap := iop.GetISO8601DateMap(time.Now())
 		cfg.TgtConn.Set(g.M("url", g.Rm(uri, dateMap)))
@@ -251,7 +255,7 @@ func (t *TaskExecution) WriteToDb(cfg *Config, df *iop.Dataflow, tgtConn databas
 		return 0, err
 	}
 
-	df.Unpause() // Resume dataflow
+	df.Unpause() // Resume dataflow (also signals castPlanReady)
 	t.SetProgress("streaming data")
 
 	// Set batch limit if specified
@@ -583,7 +587,7 @@ func (t *TaskExecution) writeDirectly(cfg *Config, df *iop.Dataflow, tgtConn dat
 		}
 	}
 
-	df.Unpause() // Resume dataflow
+	df.Unpause() // Resume dataflow (also signals castPlanReady)
 	t.SetProgress("streaming data (direct insert)")
 
 	// Set batch limit if specified


### PR DESCRIPTION
Two fixes for the columnar insert fast path:

1. Float64 precision: The buffer-replay goroutine could process the first rows before ApplyTargetCastPlan set the fast cast plan, causing those rows to fall through to CastRow which applies max_decimals=11 truncation. Add a castPlanReady channel so the goroutine waits for the plan (or pause signal) before replaying buffer rows. Signal deterministically from:
   - ApplyTargetCastPlan (Proton targets, first stream)
   - PushStreamChan (subsequent streams with plan already set)
   - Unpause (all database targets, after setup is complete)
   - WriteToFile (file/stdout targets, no Pause/Unpause cycle)
   - WaitReady (standalone consumers like Collect)

2. Column order guard: The columnar buffer uses positional indexing, so column order mismatches would silently corrupt data. Add verifyColumnOrder() check per-batch that fails fast on mismatch.

Includes regression tests for both fixes.